### PR TITLE
feat: Allow optional text stream for chat completions

### DIFF
--- a/adaptive-backend/internal/services/stream_readers/utils.go
+++ b/adaptive-backend/internal/services/stream_readers/utils.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/valyala/fasthttp"
+	"strings" // Added for strings.TrimSpace and strings.HasPrefix
 )
 
 // handleStream manages the streaming response to the client
-func HandleStream(c *fiber.Ctx, resp *models.ChatCompletionResponse, requestID string) error {
+func HandleStream(c *fiber.Ctx, resp *models.ChatCompletionResponse, requestID string, streamOpt models.StreamOption) error {
 	c.Context().SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
 		streamReader, err := GetStreamReader(resp, resp.Provider, requestID)
 		if err != nil {
@@ -23,7 +24,7 @@ func HandleStream(c *fiber.Ctx, resp *models.ChatCompletionResponse, requestID s
 
 		defer closeStreamReader(streamReader, requestID)
 
-		if err := pumpStreamData(w, streamReader, requestID); err != nil {
+		if err := pumpStreamData(w, streamReader, requestID, streamOpt); err != nil {
 			sendErrorEvent(w, requestID, "Stream error", err)
 		}
 	}))
@@ -39,26 +40,50 @@ func closeStreamReader(streamReader io.ReadCloser, requestID string) {
 	log.Printf("[%s] Stream completed", requestID)
 }
 
-func pumpStreamData(w *bufio.Writer, streamReader io.Reader, requestID string) error {
-	buffer := make([]byte, 1024)
+func pumpStreamData(w *bufio.Writer, streamReader io.Reader, requestID string, streamOpt models.StreamOption) error {
 	startTime := time.Now()
 
-	for {
-		n, err := streamReader.Read(buffer)
-
-		if n > 0 {
-			if err := writeAndFlush(w, buffer[:n], requestID); err != nil {
-				return err
+	if streamOpt == models.TEXT {
+		scanner := bufio.NewScanner(streamReader)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "data: ") {
+				payload := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+				if payload == "[DONE]" {
+					continue // Skip [DONE] messages
+				}
+				if _, err := w.WriteString(payload + "\n"); err != nil {
+					return fmt.Errorf("[%s] writing text data to response: %w", requestID, err)
+				}
+				if err := w.Flush(); err != nil {
+					return fmt.Errorf("[%s] flushing text data: %w", requestID, err)
+				}
 			}
 		}
-
-		if err == io.EOF {
-			log.Printf("[%s] Stream completed after %v", requestID, time.Since(startTime))
-			return nil
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("[%s] reading from stream with scanner: %w", requestID, err)
 		}
+		log.Printf("[%s] TEXT Stream completed after %v", requestID, time.Since(startTime))
+		return nil
+	} else { // Default to SSE or other modes
+		buffer := make([]byte, 1024)
+		for {
+			n, err := streamReader.Read(buffer)
 
-		if err != nil {
-			return fmt.Errorf("reading from stream: %w", err)
+			if n > 0 {
+				if err := writeAndFlush(w, buffer[:n], requestID); err != nil {
+					return err
+				}
+			}
+
+			if err == io.EOF {
+				log.Printf("[%s] SSE Stream completed after %v", requestID, time.Since(startTime))
+				return nil
+			}
+
+			if err != nil {
+				return fmt.Errorf("[%s] reading from stream: %w", requestID, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This change introduces the ability for you to specify the response stream type for the chat completions stream endpoint. You can now choose between:

- SSE (Server-Sent Events): This is the existing and default behavior, ensuring backward compatibility.
- Text Stream: A plain text stream where each message is a JSON object followed by a newline.

Modifications:

- Updated `adaptive-backend/internal/models/llms.go`: No changes were needed as the existing `ChatCompletionRequest` with `RequestOptions.StreamOptions` was suitable.
- Updated `adaptive-backend/internal/api/llms.go`:
    - The `StreamChatCompletion` handler now inspects the `StreamOptions` in the request.
    - It sets the `Content-Type` header to `text/event-stream` for SSE (default) or `text/plain` for text streams.
    - The chosen `StreamOption` is passed to the `HandleStream` function.
- Updated `adaptive-backend/internal/services/stream_readers/utils.go`:
    - `HandleStream` and `pumpStreamData` functions now accept a `StreamOption`.
    - If the option is `TEXT`, `pumpStreamData` parses incoming SSE events, extracts the JSON data, and writes it to the output stream followed by a newline. SSE specific formatting (like `data: ` prefix and `[DONE]` events) are stripped.
    - If the option is `SSE`, the behavior remains unchanged, passing through the raw SSE stream.
- Added unit tests for `pumpStreamData` in `adaptive-backend/internal/services/stream_readers/utils_test.go` to cover both SSE and text stream logic.
- Unit tests for `StreamChatCompletion` in `adaptive-backend/internal/api/llms_test.go` were attempted, but full coverage was hindered by existing testability limitations in the `llms.go` source file (hard-coded dependencies and fatal errors during initialization).

This enhancement provides clients with more flexibility in consuming streamed chat completion responses.