### PR TITLE
feat: add provider segregated endpoints

### DIFF
--- a/adaptive-backend/cmd/api/main.go
+++ b/adaptive-backend/cmd/api/main.go
@@ -31,12 +31,26 @@ func SetupRoutes(app *fiber.App) {
 	apiKeyHandler := api.NewAPIKeyHandler()
 	chatCompletionHandler := api.NewChatCompletionHandler()
 
+	// Create provider-specific handlers
+	openaiHandler := api.NewOpenAIChatCompletionHandler()
+	anthropicHandler := api.NewAnthropicChatCompletionHandler()
+	groqHandler := api.NewGroqChatCompletionHandler()
+	deepseekHandler := api.NewDeepSeekChatCompletionHandler()
+	geminiHandler := api.NewGeminiChatCompletionHandler()
+
 	authMiddleware := middleware.AuthMiddleware()
 	apiKeyMiddleware := middleware.APIKeyMiddleware(apiKeyHandler)
 
 	// OpenAI-compatible API routes
 	v1Group := app.Group("/v1")
 	v1Group.Post("/chat/completions", apiKeyMiddleware, chatCompletionHandler.ChatCompletion)
+
+	// Provider-specific routes
+	v1Group.Post("/openai/chat/completions", apiKeyMiddleware, openaiHandler.ChatCompletion)
+	v1Group.Post("/anthropic/chat/completions", apiKeyMiddleware, anthropicHandler.ChatCompletion)
+	v1Group.Post("/groq/chat/completions", apiKeyMiddleware, groqHandler.ChatCompletion)
+	v1Group.Post("/deepseek/chat/completions", apiKeyMiddleware, deepseekHandler.ChatCompletion)
+	v1Group.Post("/gemini/chat/completions", apiKeyMiddleware, geminiHandler.ChatCompletion)
 
 	// API group for internal management
 	apiGroup := app.Group("/api")
@@ -139,9 +153,14 @@ func main() {
 			"go_version": runtime.Version(),
 			"status":     "running",
 			"endpoints": map[string]string{
-				"metrics":  "/metrics",
-				"chat":     "/v1/chat/completions",
-				"api_keys": "/api/api_keys",
+				"metrics":   "/metrics",
+				"chat":      "/v1/chat/completions",
+				"openai":    "/v1/openai/chat/completions",
+				"anthropic": "/v1/anthropic/chat/completions",
+				"groq":      "/v1/groq/chat/completions",
+				"deepseek":  "/v1/deepseek/chat/completions",
+				"gemini":    "/v1/gemini/chat/completions",
+				"api_keys":  "/api/api_keys",
 			},
 		})
 	})

--- a/adaptive-backend/go.mod
+++ b/adaptive-backend/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/botirk38/semanticcache v0.1.1
 	github.com/clerk/clerk-sdk-go/v2 v2.2.0
 	github.com/gofiber/fiber/v2 v2.52.6
+	github.com/hashicorp/golang-lru v1.0.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/openai/openai-go v1.1.0
 	github.com/prometheus/client_golang v1.22.0

--- a/adaptive-backend/go.sum
+++ b/adaptive-backend/go.sum
@@ -109,6 +109,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
+github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=

--- a/adaptive-backend/internal/api/completions.go
+++ b/adaptive-backend/internal/api/completions.go
@@ -150,7 +150,6 @@ func (h *ChatCompletionHandler) selectModel(req *models.ChatCompletionRequest, a
 	if cacheType == "user" || cacheType == "global" {
 		h.recordCacheHit(cacheType)
 	}
-	h.recordCacheLookup("model_selection")
 
 	return modelInfo, err
 }

--- a/adaptive-backend/internal/models/completions.go
+++ b/adaptive-backend/internal/models/completions.go
@@ -6,9 +6,9 @@ import (
 	"github.com/openai/openai-go/shared"
 )
 
-// PromptRequest represents the prompt request body
 type SelectModelRequest struct {
-	Prompt string `json:"prompt"`
+	Prompt   string  `json:"prompt"`
+	Provider *string `json:"provider,omitempty"`
 }
 
 // SelectModelResponse represents the response from the select-model endpoint

--- a/adaptive-backend/internal/models/completions.go
+++ b/adaptive-backend/internal/models/completions.go
@@ -7,8 +7,8 @@ import (
 )
 
 type SelectModelRequest struct {
-	Prompt   string  `json:"prompt"`
-	Provider *string `json:"provider,omitempty"`
+	Prompt   string `json:"prompt"`
+	Provider string `json:"provider,omitempty"`
 }
 
 // SelectModelResponse represents the response from the select-model endpoint

--- a/adaptive-backend/internal/services/ai_service_client.go
+++ b/adaptive-backend/internal/services/ai_service_client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/botirk38/semanticcache"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/openai/openai-go"
 )
 

--- a/adaptive-backend/internal/services/ai_service_client.go
+++ b/adaptive-backend/internal/services/ai_service_client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/botirk38/semanticcache"
-	"github.com/hashicorp/golang-lru/v2"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/openai/openai-go"
 )
 
@@ -116,13 +116,13 @@ func (c *PromptClassifierClient) getUserCache(userID string) *semanticcache.Sema
 	return newCache
 }
 
-func (c *PromptClassifierClient) getFallbackModel(provider *string) *models.SelectModelResponse {
+func (c *PromptClassifierClient) getFallbackModel(provider string) *models.SelectModelResponse {
 	var selectedModel string
 	var fallbackProvider string
 
-	if provider != nil {
+	if provider != "" {
 		// Provider-specific fallbacks
-		switch *provider {
+		switch provider {
 		case "openai":
 			selectedModel = "gpt-4o"
 			fallbackProvider = "openai"
@@ -192,8 +192,8 @@ func (c *PromptClassifierClient) SelectModelWithCache(req models.SelectModelRequ
 
 	// Create cache key that includes provider constraint
 	cacheKey := req.Prompt
-	if req.Provider != nil {
-		cacheKey = fmt.Sprintf("%s:provider:%s", req.Prompt, *req.Provider)
+	if req.Provider != "" {
+		cacheKey = fmt.Sprintf("%s:provider:%s", req.Prompt, req.Provider)
 	}
 
 	// Check user-specific cache
@@ -227,8 +227,8 @@ func (c *PromptClassifierClient) SelectModelWithCache(req models.SelectModelRequ
 		log.Printf("[%s] Cache miss - using fallback model %s (circuit: %v)", requestID, modelInfo.SelectedModel, c.circuitBreaker.GetState())
 	} else {
 		providerText := "all providers"
-		if req.Provider != nil {
-			providerText = *req.Provider
+		if req.Provider != "" {
+			providerText = req.Provider
 		}
 		log.Printf("[%s] Cache miss - selected model %s from %s", requestID, modelInfo.SelectedModel, providerText)
 	}
@@ -265,3 +265,4 @@ func (c *PromptClassifierClient) startCacheMaintenance() {
 func (c *PromptClassifierClient) performCacheMaintenance() {
 	log.Printf("Cache maintenance completed")
 }
+

--- a/adaptive-backend/internal/services/metrics/chat-metrics.go
+++ b/adaptive-backend/internal/services/metrics/chat-metrics.go
@@ -19,7 +19,7 @@ func NewChatMetrics() *ChatMetrics {
 		RequestDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name: "chat_completion_duration_seconds",
 			Help: "Duration of chat completion requests",
-		}, []string{"endpoint", "status", "provider"}),
+		}, []string{"method_type", "status", "provider"}),
 
 		CacheHits: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "chat_completion_cache_hits_total",

--- a/adaptive-backend/internal/services/metrics/chat-metrics.go
+++ b/adaptive-backend/internal/services/metrics/chat-metrics.go
@@ -19,20 +19,20 @@ func NewChatMetrics() *ChatMetrics {
 		RequestDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name: "chat_completion_duration_seconds",
 			Help: "Duration of chat completion requests",
-		}, []string{"endpoint", "status"}),
+		}, []string{"endpoint", "status", "provider"}),
 
 		CacheHits: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "chat_completion_cache_hits_total",
 			Help: "Number of cache hits",
-		}, []string{"cache_type"}),
+		}, []string{"cache_type", "provider"}),
 
 		ModelSelections: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "chat_completion_model_selections_total",
 			Help: "Number of times each model was selected",
-		}, []string{"model"}),
+		}, []string{"model", "provider"}),
 		CacheLookups: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "chat_completion_cache_lookups_total",
 			Help: "Number of cache lookups by type (user/global/miss)",
-		}, []string{"cache_type"}),
+		}, []string{"cache_type", "provider"}),
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added provider-specific chat completion endpoints for OpenAI, Anthropic, Groq, DeepSeek, and Gemini, allowing users to target a specific provider or use the unified endpoint for optimal model selection.
- **Documentation**
  - Updated README with clearer usage examples, detailed API endpoint descriptions, and guidance on routing requests to specific providers.
- **Bug Fixes**
  - Improved fallback model selection and caching to be provider-aware, ensuring more accurate and efficient responses when constraining by provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->