### PR TITLE
refactor(models.py, main.py): simplify model selection response to use model IDs only instead of RegistryModel

### DIFF
--- a/adaptive_router/app/models.py
+++ b/adaptive_router/app/models.py
@@ -255,12 +255,12 @@ class ModelSelectionAPIRequest(BaseModel):
 
 
 class ModelSelectionAPIResponse(BaseModel):
-    """Enriched model selection response with full registry data.
+    """Simplified model selection response with model IDs only.
 
     Attributes:
-        selected_model: Full RegistryModel object for the selected model
-        alternatives: List of RegistryModel objects for alternative models
+        selected_model: Model ID string (author/model_name format)
+        alternatives: List of model ID strings for alternative models
     """
 
-    selected_model: RegistryModel
-    alternatives: list[RegistryModel]
+    selected_model: str
+    alternatives: list[str]


### PR DESCRIPTION


## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [ ] Tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated model selection API response format to return model identifiers as strings instead of full model objects for both selected and alternative models, simplifying the response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->