### PR TITLE
fix: resolve buffer dtype mismatch error in cluster engine

### DIFF
--- a/adaptive_router/core/cluster_engine.py
+++ b/adaptive_router/core/cluster_engine.py
@@ -257,7 +257,8 @@ class ClusterEngine(BaseEstimator):
             Normalized features as float32 array
         """
         features_normalized = normalize(features, norm=norm, copy=False)
-        return features_normalized.astype(np.float32, copy=False)
+        # Always ensure float32 for sklearn KMeans compatibility
+        return np.asarray(features_normalized, dtype=np.float32)
 
     @property
     def is_fitted(self) -> bool:


### PR DESCRIPTION
- Fix ValueError: Buffer dtype mismatch, expected 'const float' but got 'double'
- Ensure _normalize_features always returns float32 arrays for sklearn compatibility
- Replace astype(copy=False) with np.asarray(dtype=np.float32) for guaranteed conversion
- Verified with all tests passing (76/76 core tests)

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [ ] Tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal numerical data type handling for improved consistency with external library compatibility standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->