### PR TITLE
Fix dtype mismatch error in cluster center restoration

### DIFF
--- a/adaptive_router/core/router.py
+++ b/adaptive_router/core/router.py
@@ -325,7 +325,7 @@ class ModelRouter:
         # Restore K-means
         cluster_engine.kmeans = KMeans(n_clusters=profile.cluster_centers.n_clusters)
         cluster_engine.kmeans.cluster_centers_ = np.array(
-            profile.cluster_centers.cluster_centers
+            profile.cluster_centers.cluster_centers, dtype=np.float32
         )
         # Set required K-means attributes
         cluster_engine.kmeans._n_threads = 1


### PR DESCRIPTION
- Add explicit dtype=np.float32 when loading cluster centers from profile
- Prevents sklearn KMeans 'Buffer dtype mismatch' error during inference
- Ensures consistency between float32 embeddings and float32 centroids
- Fixes production crash when routing requests

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [ ] Tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know.