### PR TITLE
fix: cast embeddings and cluster_centers to float32 to resolve sklearn dtype mismatch

### DIFF
--- a/adaptive_router/core/cluster_engine.py
+++ b/adaptive_router/core/cluster_engine.py
@@ -314,7 +314,9 @@ class ClusterEngine(BaseEstimator):
 
         # Normalize
         norm_strategy = self.normalization_strategy or "l2"
-        embeddings_normalized = self._normalize_features(embeddings, norm=norm_strategy)
+        embeddings_normalized = self._normalize_features(
+            embeddings, norm=norm_strategy
+        ).astype(np.float32)
 
         # Predict clusters
         return self.kmeans.predict(embeddings_normalized).astype(np.int32)
@@ -348,7 +350,9 @@ class ClusterEngine(BaseEstimator):
 
         # Normalize
         norm_strategy = self.normalization_strategy or "l2"
-        embeddings_normalized = self._normalize_features(embeddings, norm=norm_strategy)
+        embeddings_normalized = self._normalize_features(
+            embeddings, norm=norm_strategy
+        ).astype(np.float32)
 
         # Predict cluster and compute distance
         cluster_id = int(self.kmeans.predict(embeddings_normalized)[0])
@@ -434,7 +438,7 @@ class ClusterEngine(BaseEstimator):
 
         # Create KMeans with fitted state
         engine.kmeans = KMeans(n_clusters=n_clusters)
-        engine.kmeans.cluster_centers_ = cluster_centers
+        engine.kmeans.cluster_centers_ = cluster_centers.astype(np.float32)
         engine.kmeans.n_iter_ = clustering_config.n_iter if clustering_config else 0
         engine.kmeans.n_features_in_ = cluster_centers.shape[1]
         engine.kmeans._n_threads = 1  # Runtime default for sklearn 1.4+


### PR DESCRIPTION


- Cast embeddings_normalized to float32 in predict() method
- Cast embeddings_normalized to float32 in assign_single() method
- Cast cluster_centers to float32 when restoring from fitted state

Fixes ValueError: Buffer dtype mismatch, expected 'const float' but got 'double'

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [ ] Tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know.