### PR TITLE
fix: make CUDA libraries PUBLIC to propagate include directories

### DIFF
--- a/adaptive_router_core/core/src/cuda/CMakeLists.txt
+++ b/adaptive_router_core/core/src/cuda/CMakeLists.txt
@@ -19,9 +19,10 @@ target_include_directories(adaptive_cuda
 )
 
 target_link_libraries(adaptive_cuda
-  PRIVATE
+  PUBLIC
     CUDA::cublas
     CUDA::cudart
+  PRIVATE
     Eigen3::Eigen
 )
 


### PR DESCRIPTION
Make CUDA::cublas and CUDA::cudart PUBLIC in adaptive_cuda target so that CUDA Toolkit include directories are available to targets that link to adaptive_cuda, fixing cublas_v2.h not found errors.

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [ ] Tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information that reviewers should know.